### PR TITLE
Add `yargs` to `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,7 @@
     'husky',
     'nyc',
     'prettier',
-    'test-each'
+    'test-each',
+    'yargs'
   ]
 }


### PR DESCRIPTION
Yargs v16.0.0 drops support for Node 8, so we cannot upgrade it.