### PR TITLE
Add `del` to `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,6 +7,7 @@
   ignoreDeps: [
     // Those cannot be upgraded until we drop support for Node 8
     'ava',
+    'del',
     'eslint',
     'execa',
     'get-bin-path',


### PR DESCRIPTION
This adds `del` to the list of excluded dependencies in `renovate.json5` (no Node 8 support).