### PR TITLE
Add `is-plain-obj` to `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,6 +12,7 @@
     'execa',
     'get-bin-path',
     'husky',
+    'is-plain-obj',
     'nyc',
     'prettier',
     'test-each',


### PR DESCRIPTION
Latest `is-plain-obj` is not compatible with Node 8