### PR TITLE
Add `hasFramework()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following frameworks are detected:
 # Example (Node.js)
 
 ```js
-const { listFrameworks, getFramework } = require('@netlify/framework-info')
+const { listFrameworks, hasFramework, getFramework } = require('@netlify/framework-info')
 
 console.log(await listFrameworks({ projectDir: './path/to/gatsby/website' }))
 // [
@@ -49,6 +49,9 @@ console.log(await listFrameworks({ projectDir: './path/to/vue/website' }))
 //     env: {}
 //   }
 // ]
+
+console.log(await hasFramework('vue', { projectDir: './path/to/vue/website' }))
+// true
 
 console.log(await getFramework('vue', { projectDir: './path/to/vue/website' }))
 // {
@@ -160,6 +163,13 @@ Server port.
 _Type_: `object`
 
 Environment variables that should be set when calling the watch command.
+
+## hasFramework(frameworkName, options?)
+
+`options`: `object?`\
+_Return value_: `Promise<boolean>`
+
+Same as [`listFramework()`](#listframeworksoptions) except only for a specific framework and returns a boolean.
 
 ## getFramework(frameworkName, options?)
 

--- a/src/main.js
+++ b/src/main.js
@@ -32,8 +32,27 @@ const listFrameworks = async function(opts) {
 }
 
 /**
+ * Return whether a project uses a specific framework
+ *
+ * @param {string} frameworkName - Name such as `"gatsby"`
+ * @param  {object} [options] - Options
+ * @param  {string} [flags.projectDir=process.cwd()] - Project's directory
+ * @param  {string} [flags.ignoredWatchCommand] - When guessing the watch command, ignore `package.json` `scripts` whose value includes this string
+ *
+ * @returns {boolean} result - Whether the project uses this framework
+ */
+const hasFramework = async function(frameworkName, opts) {
+  const framework = getFrameworkByName(frameworkName)
+  const { projectDir, ignoredWatchCommand } = getOptions(opts)
+  const { npmDependencies } = await getProjectInfo({ projectDir, ignoredWatchCommand })
+  const result = await usesFramework(framework, { projectDir, npmDependencies })
+  return result
+}
+
+/**
  * Return some information about a framework used by a project.
  *
+ * @param {string} frameworkName - Name such as `"gatsby"`
  * @param  {object} [options] - Options
  * @param  {string} [flags.projectDir=process.cwd()] - Project's directory
  * @param  {string} [flags.ignoredWatchCommand] - When guessing the watch command, ignore `package.json` `scripts` whose value includes this string
@@ -82,4 +101,4 @@ const getFrameworkInfo = function(
   return { name, category, watch: { commands: watchCommands, directory, port }, env }
 }
 
-module.exports = { listFrameworks, getFramework }
+module.exports = { listFrameworks, hasFramework, getFramework }

--- a/test/helpers/main.js
+++ b/test/helpers/main.js
@@ -1,4 +1,4 @@
-const { listFrameworks, getFramework: getFrameworkLib } = require('../../src/main.js')
+const { listFrameworks, getFramework: getFrameworkLib, hasFramework: hasFrameworkLib } = require('../../src/main.js')
 
 const FIXTURES_DIR = `${__dirname}/../fixtures`
 
@@ -11,4 +11,8 @@ const getFramework = function(fixtureName, frameworkName, opts = {}) {
   return getFrameworkLib(frameworkName, { projectDir: `${FIXTURES_DIR}/${fixtureName}`, ...opts })
 }
 
-module.exports = { getFrameworks, getFramework, FIXTURES_DIR }
+const hasFramework = function(fixtureName, frameworkName, opts = {}) {
+  return hasFrameworkLib(frameworkName, { projectDir: `${FIXTURES_DIR}/${fixtureName}`, ...opts })
+}
+
+module.exports = { getFrameworks, getFramework, hasFramework, FIXTURES_DIR }

--- a/test/main.js
+++ b/test/main.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 
-const { getFrameworks, getFramework } = require('./helpers/main.js')
+const { getFrameworks, getFramework, hasFramework } = require('./helpers/main.js')
 
 test('Should detect frameworks', async t => {
   const frameworks = await getFrameworks('simple')
@@ -22,6 +22,18 @@ test('Should allow getting a specific framework', async t => {
   t.snapshot(framework)
 })
 
-test('Should throw when passing an inva;lid framework', async t => {
+test('Should throw when passing an invalid framework', async t => {
   await t.throwsAsync(getFramework('simple', 'doesNotExist'))
+})
+
+test('Should allow testing a specific framework', async t => {
+  const trueResult = await hasFramework('simple', 'sapper')
+  t.true(trueResult)
+
+  const falseResult = await hasFramework('simple', 'nuxt')
+  t.false(falseResult)
+})
+
+test('Should throw when testing an invalid framework', async t => {
+  await t.throwsAsync(hasFramework('simple', 'doesNotExist'))
 })


### PR DESCRIPTION
This adds an `hasFramework()` method to make it possible to check if a project uses a specific framework without having to list all frameworks.

This is meant to be used by the Next.js plugin: https://github.com/netlify/netlify-plugin-nextjs/blob/7b9a2430f46da57a38c5c85d611b2fc7df6bd777/index.js#L14