### PR TITLE
fix: add missing frameworks to main.js

### DIFF
--- a/src/frameworks/main.js
+++ b/src/frameworks/main.js
@@ -4,6 +4,7 @@
 const FRAMEWORKS = [
   // Static site generators
   require('./docusaurus.json'),
+  require('./docusaurus-v2.json'),
   require('./eleventy.json'),
   require('./gatsby.json'),
   require('./gridsome.json'),
@@ -24,6 +25,7 @@ const FRAMEWORKS = [
   require('./ember.json'),
   require('./expo.json'),
   require('./quasar.json'),
+  require('./quasar-v0.17.json'),
   require('./sapper.json'),
   require('./svelte.json'),
   require('./vue.json'),

--- a/test/frameworks.js
+++ b/test/frameworks.js
@@ -1,8 +1,15 @@
+const fs = require('fs')
+const path = require('path')
+const util = require('util')
+
 const Ajv = require('ajv')
 const test = require('ava')
 const { each } = require('test-each')
 
 const { FRAMEWORKS } = require('../src/frameworks/main.js')
+
+const pReadDir = util.promisify(fs.readdir)
+const pReadFile = util.promisify(fs.readFile)
 
 const ajv = new Ajv({})
 
@@ -73,4 +80,14 @@ each(FRAMEWORKS, (info, framework) => {
   test(`Framework "${framework.name}" should have a valid shape`, (t) => {
     t.is(validate(framework, FRAMEWORK_JSON_SCHEMA), true)
   })
+})
+
+test('each json file should be required in main.js FRAMEWORKS', async (t) => {
+  const dir = path.join(__dirname, '..', 'src', 'frameworks')
+  const jsonFiles = (await pReadDir(dir)).filter((file) => path.extname(file) === '.json')
+
+  const mainFile = await pReadFile(path.join(dir, 'main.js'), 'utf8')
+
+  const missing = jsonFiles.filter((file) => !mainFile.includes(`./${file}`))
+  t.deepEqual(missing, [])
 })

--- a/test/frameworks.js
+++ b/test/frameworks.js
@@ -83,10 +83,10 @@ each(FRAMEWORKS, (info, framework) => {
 })
 
 test('each json file should be required in main.js FRAMEWORKS', async (t) => {
-  const dir = path.join(__dirname, '..', 'src', 'frameworks')
+  const dir = `${__dirname}/../src/frameworks`
   const jsonFiles = (await pReadDir(dir)).filter((file) => path.extname(file) === '.json')
 
-  const mainFile = await pReadFile(path.join(dir, 'main.js'), 'utf8')
+  const mainFile = await pReadFile(`${dir}/main.js`, 'utf8')
 
   const missing = jsonFiles.filter((file) => !mainFile.includes(`./${file}`))
   t.deepEqual(missing, [])


### PR DESCRIPTION
This adds missing frameworks to `main.js` and adds a test to verify there are no missing ones