### PR TITLE
chore: use release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,14 @@
+name: release-please
+on:
+  push:
+    branches:
+      - master
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node
+          package-name: "@netlify/framework-info"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,10 @@ The following things are tested for:
 
 ## Releasing
 
-```console
-$ npm version [major|minor|patch]
-$ npm publish [--tag=TAG]
-```
+1. Merge the release PR
+2. Switch to the default branch `git checkout master`
+3. Pull latest changes `git pull`
+4. Publish the package `npm publish`
 
 ## License
 


### PR DESCRIPTION
This changes our publishing flow to use release PRs.
See example:
https://github.com/erezrokah/netlify-plugin-is-website-vulnerable/pull/102
https://github.com/erezrokah/netlify-plugin-is-website-vulnerable/releases/tag/v1.0.11

We can port it to other repos if it works well.

> npm publishing part is still done locally