### PR TITLE
fix(watch-command): return watch commands in consistent order

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -25,7 +25,12 @@ const getScriptWatchCommands = function (scripts, frameworkWatchCommand) {
   return watchScripts.sort(scriptsSorter)
 }
 
-const scriptsSorter = (script1, script2) => NPM_WATCH_SCRIPTS.indexOf(script1) - NPM_WATCH_SCRIPTS.indexOf(script2)
+const scriptsSorter = (script1, script2) => {
+  const index1 = NPM_WATCH_SCRIPTS.findIndex((watchScriptName) => matchesNpmWatchScript(script1, watchScriptName))
+  const index2 = NPM_WATCH_SCRIPTS.findIndex((watchScriptName) => matchesNpmWatchScript(script2, watchScriptName))
+
+  return index1 - index2
+}
 
 const getPreferredScripts = function (scripts, frameworkWatchCommand) {
   return Object.entries(scripts)

--- a/src/watch.js
+++ b/src/watch.js
@@ -20,8 +20,12 @@ const getScriptWatchCommands = function (scripts, frameworkWatchCommand) {
     return preferredScripts
   }
 
-  return Object.keys(scripts).filter(isNpmWatchScript)
+  const watchScripts = Object.keys(scripts).filter(isNpmWatchScript)
+  // eslint-disable-next-line fp/no-mutating-methods
+  return watchScripts.sort(scriptsSorter)
 }
+
+const scriptsSorter = (script1, script2) => NPM_WATCH_SCRIPTS.indexOf(script1) - NPM_WATCH_SCRIPTS.indexOf(script2)
 
 const getPreferredScripts = function (scripts, frameworkWatchCommand) {
   return Object.entries(scripts)

--- a/test/fixtures/scripts-order/build-first/package.json
+++ b/test/fixtures/scripts-order/build-first/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "build": "rollup -c",
+    "dev": "rollup -c -w",
+    "start": "sirv public"
+  },
+  "devDependencies": {
+    "svelte": "^3.0.0"
+  }
+}

--- a/test/fixtures/scripts-order/dev-first/package.json
+++ b/test/fixtures/scripts-order/dev-first/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "dev": "rollup -c -w",
+    "build": "rollup -c",
+    "start": "sirv public"
+  },
+  "devDependencies": {
+    "svelte": "^3.0.0"
+  }
+}

--- a/test/fixtures/scripts-order/postfix-format/package.json
+++ b/test/fixtures/scripts-order/postfix-format/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "site:build": "rollup -c",
+    "site:start": "sirv public",
+    "site:dev": "rollup -c -w"
+  },
+  "devDependencies": {
+    "svelte": "^3.0.0"
+  }
+}

--- a/test/run_script.js
+++ b/test/run_script.js
@@ -5,5 +5,5 @@ const { getFrameworks } = require('./helpers/main.js')
 test('Should use Yarn when there is a yarn.lock', async (t) => {
   const frameworks = await getFrameworks('yarn_scripts')
   t.is(frameworks.length, 1)
-  t.deepEqual(frameworks[0].watch.commands, ['yarn start', 'yarn dev'])
+  t.deepEqual(frameworks[0].watch.commands, ['yarn dev', 'yarn start'])
 })

--- a/test/watch.js
+++ b/test/watch.js
@@ -5,7 +5,7 @@ const { getFrameworks } = require('./helpers/main.js')
 test('Should use package scripts as watch command', async (t) => {
   const frameworks = await getFrameworks('use_scripts')
   t.is(frameworks.length, 1)
-  t.deepEqual(frameworks[0].watch.commands, ['npm run start', 'npm run dev'])
+  t.deepEqual(frameworks[0].watch.commands, ['npm run dev', 'npm run start'])
 })
 
 test('Should allow package scripts names with colons', async (t) => {
@@ -24,4 +24,15 @@ test('Should default watch.commands to framework.watch.command', async (t) => {
   const frameworks = await getFrameworks('empty_scripts')
   t.is(frameworks.length, 1)
   t.deepEqual(frameworks[0].watch.commands, ['sapper dev'])
+})
+
+test('Should return the same result when script order is different', async (t) => {
+  const frameworksBuildFirst = await getFrameworks('scripts-order/build-first')
+  const frameworksDevFirst = await getFrameworks('scripts-order/dev-first')
+
+  t.is(frameworksBuildFirst.length, 1)
+  t.is(frameworksDevFirst.length, 1)
+
+  t.deepEqual(frameworksBuildFirst[0].watch.commands, ['npm run dev', 'npm run start', 'npm run build'])
+  t.deepEqual(frameworksBuildFirst, frameworksDevFirst)
 })

--- a/test/watch.js
+++ b/test/watch.js
@@ -36,3 +36,11 @@ test('Should return the same result when script order is different', async (t) =
   t.deepEqual(frameworksBuildFirst[0].watch.commands, ['npm run dev', 'npm run start', 'npm run build'])
   t.deepEqual(frameworksBuildFirst, frameworksDevFirst)
 })
+
+test('Should sort scripts in the format *:<name>', async (t) => {
+  const frameworks = await getFrameworks('scripts-order/postfix-format')
+
+  t.is(frameworks.length, 1)
+
+  t.deepEqual(frameworks[0].watch.commands, ['npm run site:dev', 'npm run site:start', 'npm run site:build'])
+})


### PR DESCRIPTION
Related to https://github.com/netlify/cli/issues/1252#issuecomment-708618270 and I also noticed this impacts the `svelte` detector.

We should return the same result if script order is different.

We should also find a way to sort https://github.com/netlify/framework-info/blob/26a3b71c04d02c0a1d1baa3dbbc69745adc6683d/src/watch.js#L27 but I'm not sure how to do it (yet).