### PR TITLE
chore(ci): use personal access token for releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.NODE_PKG_RELEASE_TOKEN }}
           release-type: node
-          package-name: "@netlify/framework-info"
+          package-name: '@netlify/framework-info'


### PR DESCRIPTION
This is required for `create-release` PRs to have status checks. See https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token