### PR TITLE
fix: sort preferred scripts

### DIFF
--- a/src/dev.js
+++ b/src/dev.js
@@ -28,17 +28,21 @@ const getScriptDevCommands = function (scripts, frameworkDevCommand) {
   return devScripts.sort(scriptsSorter)
 }
 
+const getSortIndex = (index) => (index === -1 ? Number.MAX_SAFE_INTEGER : index)
+
 const scriptsSorter = (script1, script2) => {
   const index1 = NPM_DEV_SCRIPTS.findIndex((devScriptName) => matchesNpmWDevScript(script1, devScriptName))
   const index2 = NPM_DEV_SCRIPTS.findIndex((devScriptName) => matchesNpmWDevScript(script2, devScriptName))
 
-  return index1 - index2
+  return getSortIndex(index1) - getSortIndex(index2)
 }
 
 const getPreferredScripts = function (scripts, frameworkDevCommand) {
+  // eslint-disable-next-line fp/no-mutating-methods
   return Object.entries(scripts)
     .filter(([, scriptValue]) => scriptValue.includes(frameworkDevCommand))
     .map((script) => getEntryKey(script))
+    .sort(scriptsSorter)
 }
 
 const getEntryKey = function ([key]) {

--- a/test/dev.js
+++ b/test/dev.js
@@ -45,7 +45,7 @@ test('Should sort scripts in the format *:<name>', async (t) => {
   t.deepEqual(frameworks[0].dev.commands, ['npm run site:dev', 'npm run site:start', 'npm run site:build'])
 })
 
-test('Should sort scripts when dev command is substring of build command', async (t) => {
+test('Should sort scripts when dev command is a substring of build command', async (t) => {
   const frameworks = await getFrameworks('scripts-order/command-substring')
 
   t.is(frameworks.length, 1)

--- a/test/dev.js
+++ b/test/dev.js
@@ -44,3 +44,11 @@ test('Should sort scripts in the format *:<name>', async (t) => {
 
   t.deepEqual(frameworks[0].dev.commands, ['npm run site:dev', 'npm run site:start', 'npm run site:build'])
 })
+
+test('Should sort scripts when dev command is substring of build command', async (t) => {
+  const frameworks = await getFrameworks('scripts-order/command-substring')
+
+  t.is(frameworks.length, 1)
+
+  t.deepEqual(frameworks[0].dev.commands, ['npm run dev', 'npm run build'])
+})

--- a/test/fixtures/scripts-order/command-substring/package.json
+++ b/test/fixtures/scripts-order/command-substring/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "parcel-ste",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "parcel-bundler": "^1.12.4"
+  },
+  "scripts": {
+    "build": "parcel build index.html",
+    "dev": "parcel index.html"
+  }
+}


### PR DESCRIPTION
Related to https://github.com/netlify/cli/issues/1252

We need to sort the scripts when we match a preferred command