### PR TITLE
ci: use npm ci instead of install

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,6 +26,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Update npm
+        run: npm install -g npm@5
+        if: "${{ matrix.node-version == '8.3.0' }}"
       - name: Install dependencies
         run: npm ci
       - name: Build For Browser

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,8 +6,6 @@ on:
     tags: ['*']
   pull_request:
     types: [opened, synchronize, reopened]
-env:
-  CI: 'true'
 jobs:
   build:
     strategy:
@@ -29,7 +27,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Build For Browser
         run: npm run build
         if: "${{ matrix.node-version == '14' }}"


### PR DESCRIPTION
Switch to `npm ci` and remove a redundant env variable