### PR TITLE
fix: fix `files` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   "files": [
     "dist/index.js",
     "src/**/*.js",
-    "src/**/*.json",
-    "!*~"
+    "src/**/*.json"
   ],
   "scripts": {
     "prepublishOnly": "npm ci && run-s test build:core",


### PR DESCRIPTION
npm 7 changed the way globbing patterns are interpreted in `files` in `package.json`. This is undocumented, so I'm not sure whether this is a bug or not. This results in all `*~` files (Vim temporary files) to be published to npm, which can double the package size. 

This PR fixes this. I ran `npm pack --dry` before and after to ensure no files were being omitted.