### PR TITLE
chore: allow non major updates for Node.js 8 packages

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,18 +4,25 @@
   semanticCommits: true,
   masterIssue: true,
   automerge: false,
-  ignoreDeps: [
-    // Those cannot be upgraded until we drop support for Node 8
-    'ava',
-    'del',
-    'eslint',
-    'execa',
-    'get-bin-path',
-    'husky',
-    'is-plain-obj',
-    'nyc',
-    'prettier',
-    'test-each',
-    'yargs'
-  ]
+  packageRules: [
+    {
+      // Those cannot be upgraded to a major version until we drop support for Node 8
+      packageNames: [
+        'ava',
+        'del',
+        'eslint',
+        'execa',
+        'get-bin-path',
+        'husky',
+        'is-plain-obj',
+        'nyc',
+        'prettier',
+        'test-each',
+        'yargs',
+      ],
+      major: {
+        enabled: false,
+      },
+    },
+  ],
 }


### PR DESCRIPTION
Fixes the renovate config to allow minor/patch updates to ignored packages