### PR TITLE
chore: add read-pkg-up to renovate ignore list

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,6 +17,7 @@
         'is-plain-obj',
         'nyc',
         'prettier',
+        'read-pkg-up', // read-pkg-up v8 requires Node.js 12
         'test-each',
         'yargs',
       ],


### PR DESCRIPTION
See https://github.com/netlify/framework-info/pull/193

We cannot update `read-pkg-up` until we drop support for Node.js < 12