### PR TITLE
feat: Add framework detection support for RedwoodJS

### DIFF
--- a/src/frameworks/main.js
+++ b/src/frameworks/main.js
@@ -17,6 +17,7 @@ const FRAMEWORKS = [
   require('./nuxt.json'),
   require('./phenomic.json'),
   require('./react-static.json'),
+  require('./redwoodjs.json'),
   require('./stencil.json'),
   require('./vuepress.json'),
   require('./assemble.json'),

--- a/src/frameworks/redwoodjs.json
+++ b/src/frameworks/redwoodjs.json
@@ -1,0 +1,26 @@
+{
+  "id": "redwoodjs",
+  "name": "RedwoodJS",
+  "category": "static_site_generator",
+  "detect": {
+    "configFiles": [
+      "redwood.toml"
+    ]
+  },
+  "dev": {
+    "command": "rw dev",
+    "port": 8910,
+    "pollingStrategies": [
+      {
+        "name": "TCP"
+      }
+    ]
+  },
+  "build": {
+    "command": "yarn rw deploy netlify",
+    "directory": "web/dist"
+  },
+  "staticAssetsDirectory": "public",
+  "env": {},
+  "plugins": []
+}

--- a/src/frameworks/redwoodjs.json
+++ b/src/frameworks/redwoodjs.json
@@ -3,6 +3,10 @@
   "name": "RedwoodJS",
   "category": "static_site_generator",
   "detect": {
+    "npmDependencies": [
+      "@redwoodjs/core"
+    ],
+    "excludedNpmDependencies": [],
     "configFiles": [
       "redwood.toml"
     ]

--- a/src/frameworks/redwoodjs.json
+++ b/src/frameworks/redwoodjs.json
@@ -8,7 +8,7 @@
     ]
   },
   "dev": {
-    "command": "rw dev",
+    "command": "yarn rw dev",
     "port": 8910,
     "pollingStrategies": [
       {
@@ -17,7 +17,7 @@
     ]
   },
   "build": {
-    "command": "yarn rw deploy netlify",
+    "command": "rw deploy netlify",
     "directory": "web/dist"
   },
   "staticAssetsDirectory": "public",

--- a/src/frameworks/redwoodjs.json
+++ b/src/frameworks/redwoodjs.json
@@ -21,7 +21,7 @@
     ]
   },
   "build": {
-    "command": "yarn rw deploy netlify",
+    "command": "rw deploy netlify",
     "directory": "web/dist"
   },
   "staticAssetsDirectory": "public",

--- a/src/frameworks/redwoodjs.json
+++ b/src/frameworks/redwoodjs.json
@@ -17,7 +17,7 @@
     ]
   },
   "build": {
-    "command": "rw deploy netlify",
+    "command": "yarn rw deploy netlify",
     "directory": "web/dist"
   },
   "staticAssetsDirectory": "public",


### PR DESCRIPTION
We on the RedwoodJS Core Team https://redwoodjs.com noticed that that there is no Redwood common config here: https://docs.netlify.com/configure-builds/common-configurations/

And we found out that this framework detection library "helps with build settings heuristics when creating new sites or running netlify dev, and also to track usage of different tools across the [Netlify] platform". That influences things like which "common configurations" get add to the docs.

So, this PR adds framework detection for RedwoodJS so that all the above can happen.

The key way to detect is the presence of the `redwood.toml` file.

```js
  "detect": {
    "configFiles": [
      "redwood.toml"
    ]
  },
```

Thanks!