### PR TITLE
fix(jekyll): add additional config files

### DIFF
--- a/src/frameworks/jekyll.json
+++ b/src/frameworks/jekyll.json
@@ -5,7 +5,7 @@
   "detect": {
     "npmDependencies": [],
     "excludedNpmDependencies": [],
-    "configFiles": ["_config.yml"]
+    "configFiles": ["_config.yml", "_config.yaml", "_config.toml"]
   },
   "dev": {
     "command": "bundle exec jekyll serve -w",


### PR DESCRIPTION
Related to https://github.com/netlify/framework-info/issues/205 and https://github.com/netlify/cli/pull/2312

Adds missing Jekyll configuration files