### PR TITLE
feat: add detection of Next with Nx

### DIFF
--- a/src/frameworks/main.js
+++ b/src/frameworks/main.js
@@ -12,6 +12,7 @@ const FRAMEWORKS = [
   require('./hugo.json'),
   require('./jekyll.json'),
   require('./middleman.json'),
+  require('./next-nx.json'),
   require('./next.json'),
   require('./blitz.json'),
   require('./nuxt.json'),

--- a/src/frameworks/next-nx.json
+++ b/src/frameworks/next-nx.json
@@ -1,0 +1,26 @@
+{
+  "id": "next-nx",
+  "name": "Next.js with Nx",
+  "category": "static_site_generator",
+  "detect": {
+    "npmDependencies": ["@nrwl/next"],
+    "excludedNpmDependencies": [],
+    "configFiles": []
+  },
+  "dev": {
+    "command": "nx serve",
+    "port": 4200,
+    "pollingStrategies": [{ "name": "TCP" }, { "name": "HTTP" }]
+  },
+  "build": {
+    "command": "nx build",
+    "directory": "apps/<app name>/out"
+  },
+  "env": {},
+  "plugins": [
+    {
+      "packageName": "@netlify/plugin-nextjs",
+      "condition": { "minNodeVersion": "10.13.0" }
+    }
+  ]
+}

--- a/src/frameworks/next.json
+++ b/src/frameworks/next.json
@@ -4,7 +4,7 @@
   "category": "static_site_generator",
   "detect": {
     "npmDependencies": ["next"],
-    "excludedNpmDependencies": [],
+    "excludedNpmDependencies": ["@nrwl/next"],
     "configFiles": []
   },
   "dev": {


### PR DESCRIPTION
When building Next.js sites via Nx we need to use different commands and ports. See https://ntl.fyi/nx-next for docs. 
We detect `@nrwl/next` rather than `nx` because we don't want to catch other uses of Nx, e.g. Angular.