### PR TITLE
fix(framework-vite): remove HTTP polling

### DIFF
--- a/src/frameworks/vite.json
+++ b/src/frameworks/vite.json
@@ -3,18 +3,18 @@
   "name": "Vite",
   "category": "build_tool",
   "detect": {
-      "npmDependencies": ["vite"],
-      "excludedNpmDependencies": [],
-      "configFiles": []
+    "npmDependencies": ["vite"],
+    "excludedNpmDependencies": [],
+    "configFiles": []
   },
   "dev": {
-      "command": "vite",
-      "port": 3000,
-      "pollingStrategies": [{ "name": "TCP" }, { "name": "HTTP" }]
+    "command": "vite",
+    "port": 3000,
+    "pollingStrategies": [{ "name": "TCP" }]
   },
   "build": {
-      "command": "vite build",
-      "directory": "dist"
+    "command": "vite build",
+    "directory": "dist"
   },
   "env": {},
   "plugins": []


### PR DESCRIPTION
Follow up on https://github.com/netlify/cli/pull/2883

This will be required once https://github.com/netlify/cli/pull/1704 lands, see https://github.com/netlify/cli/pull/1704/files#diff-42c491dfbe209d7493ec82cd5d031be64f17cf6e622201768d29b3539194d9e1R83 vs https://github.com/netlify/cli/blob/88df4e09704567377f96035480793f602d067636/src/commands/dev/index.js#L88