### PR TITLE
fix(dev-detection): prioritize dev over serve

### DIFF
--- a/src/dev.js
+++ b/src/dev.js
@@ -57,6 +57,6 @@ const matchesNpmWDevScript = function (scriptName, devScriptName) {
   return scriptName === devScriptName || scriptName.endsWith(`:${devScriptName}`)
 }
 
-const NPM_DEV_SCRIPTS = ['serve', 'dev', 'develop', 'start', 'run', 'build', 'web']
+const NPM_DEV_SCRIPTS = ['dev', 'serve', 'develop', 'start', 'run', 'build', 'web']
 
 module.exports = { getDevCommands }

--- a/test/dev.js
+++ b/test/dev.js
@@ -52,3 +52,11 @@ test('Should sort scripts when dev command is a substring of build command', asy
 
   t.deepEqual(frameworks[0].dev.commands, ['npm run dev', 'npm run build'])
 })
+
+test('Should prioritize dev over serve', async (t) => {
+  const frameworks = await getFrameworks('scripts-order/vite-framework')
+
+  t.is(frameworks.length, 1)
+
+  t.deepEqual(frameworks[0].dev.commands, ['npm run dev', 'npm run serve', 'npm run build'])
+})

--- a/test/fixtures/scripts-order/vite-framework/package.json
+++ b/test/fixtures/scripts-order/vite-framework/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "vite-project",
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^2.1.5"
+  }
+}


### PR DESCRIPTION
Related to https://github.com/netlify/cli/pull/1704

Fixes detection for the `vite` framework where we return `npm run serve` as the first possible command instead of `npm run dev`.
Since the `vite` dev command doesn't have any arguments the detection matches all possible scripts.
We solve this by sorting the scripts based on priority.

> At the moment the CLI detection logic returns the first script as shown in `package.json` which is confusing as the script order in `package.json` impacts the https://github.com/netlify/cli/issues/1252