### PR TITLE
fix(dev): add list of excluded dev commands

### DIFF
--- a/src/dev.js
+++ b/src/dev.js
@@ -23,7 +23,7 @@ const getScriptDevCommands = function (scripts, frameworkDevCommand) {
     return preferredScripts
   }
 
-  const devScripts = Object.keys(scripts).filter((script) => isNpmDevScript(script))
+  const devScripts = Object.keys(scripts).filter((script) => isNpmDevScript(script, scripts[script]))
   return devScripts.sort(scriptsSorter)
 }
 
@@ -48,8 +48,10 @@ const getEntryKey = function ([key]) {
 }
 
 // Check if the npm script is likely to contain a dev command
-const isNpmDevScript = function (scriptName) {
-  return NPM_DEV_SCRIPTS.some((devScriptName) => matchesNpmWDevScript(scriptName, devScriptName))
+const isNpmDevScript = function (scriptName, scriptValue) {
+  return NPM_DEV_SCRIPTS.some(
+    (devScriptName) => matchesNpmWDevScript(scriptName, devScriptName) && !isExcludedScript(scriptValue),
+  )
 }
 
 // We also match script names like `docs:dev`
@@ -58,5 +60,11 @@ const matchesNpmWDevScript = function (scriptName, devScriptName) {
 }
 
 const NPM_DEV_SCRIPTS = ['dev', 'serve', 'develop', 'start', 'run', 'build', 'web']
+
+const isExcludedScript = function (scriptValue) {
+  return EXCLUDED_SCRIPTS.some((excluded) => scriptValue.includes(excluded))
+}
+
+const EXCLUDED_SCRIPTS = ['netlify dev']
 
 module.exports = { getDevCommands }

--- a/test/dev.js
+++ b/test/dev.js
@@ -60,3 +60,11 @@ test('Should prioritize dev over serve', async (t) => {
 
   t.deepEqual(frameworks[0].dev.commands, ['npm run dev', 'npm run serve', 'npm run build'])
 })
+
+test(`Should exclude 'netlify dev' script`, async (t) => {
+  const frameworks = await getFrameworks('excluded_script')
+
+  t.is(frameworks.length, 1)
+
+  t.deepEqual(frameworks[0].dev.commands, ['npm run build'])
+})

--- a/test/fixtures/excluded_script/package.json
+++ b/test/fixtures/excluded_script/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "create-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "react-scripts": "*"
+  },
+  "scripts": {
+    "start": "netlify dev",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/netlify/cli/issues/3045

Reinstates the CLI logic that filters out `netlify dev` as a dev script.

I planned to do it in the CLI as a part of https://github.com/netlify/cli/pull/1704, but forgot.

After giving it some though I think it makes sense to have it in `framework-info` as there are others scripts we might want to exclude. 