### PR TITLE
feat(gatsby): precompile functions in develop

### DIFF
--- a/src/frameworks/gatsby.json
+++ b/src/frameworks/gatsby.json
@@ -17,7 +17,7 @@
     "directory": "public"
   },
   "staticAssetsDirectory": "static",
-  "env": { "GATSBY_LOGGER": "yurnalist" },
+  "env": { "GATSBY_LOGGER": "yurnalist", "GATSBY_PRECOMPILE_DEVELOP_FUNCTIONS": "true" },
   "plugins": [
     {
       "packageName": "@netlify/plugin-gatsby",


### PR DESCRIPTION
Adds the env var `GATSBY_PRECOMPILE_DEVELOP_FUNCTIONS=true`, so that `ntl dev` can load functions directly rather than proxying