### PR TITLE
fix(sveltekit): specify better output location

### DIFF
--- a/src/frameworks/svelte-kit.json
+++ b/src/frameworks/svelte-kit.json
@@ -14,8 +14,9 @@
   },
   "build": {
     "command": "svelte-kit build",
-    "directory": "static"
+    "directory": "build"
   },
+  "staticAssetsDirectory": "static",
   "env": {},
   "plugins": []
 }


### PR DESCRIPTION
I don't know why it says `static`. That's an input directory where static assets are located and we shouldn't put output there