### PR TITLE
chore(ci): cache npm cache dir between workflow execs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '*'
+          cache: 'npm'
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
           check-latest: true
       - name: Install dependencies
         # Cypress has a postinstall script that doesn't work on older Node.js versions
@@ -59,6 +60,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '*'
+          cache: 'npm'
           check-latest: true
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/js-client/blob/main/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Related with https://github.com/netlify/team-dev/issues/31 - cache `npm cache` between workflow executions.

