### PR TITLE
feat(gatsby): set node version to 14 for build and functions

### DIFF
--- a/src/frameworks/gatsby.json
+++ b/src/frameworks/gatsby.json
@@ -17,7 +17,12 @@
     "directory": "public"
   },
   "staticAssetsDirectory": "static",
-  "env": { "GATSBY_LOGGER": "yurnalist", "GATSBY_PRECOMPILE_DEVELOP_FUNCTIONS": "true" },
+  "env": {
+    "GATSBY_LOGGER": "yurnalist",
+    "GATSBY_PRECOMPILE_DEVELOP_FUNCTIONS": "true",
+    "AWS_LAMBDA_JS_RUNTIME": "nodejs14.x",
+    "NODE_VERSION": "14"
+  },
   "plugins": [
     {
       "packageName": "@netlify/plugin-gatsby",


### PR DESCRIPTION
Gatsby 4 will require Node >= 14 so it makes sense to default new sites to that now