### PR TITLE
fix(framework-angular): updates deprecated build command

### DIFF
--- a/src/frameworks/angular.json
+++ b/src/frameworks/angular.json
@@ -13,7 +13,7 @@
     "pollingStrategies": [{ "name": "TCP" }, { "name": "HTTP" }]
   },
   "build": {
-    "command": "ng build --prod",
+    "command": "ng build --configuration production",
     "directory": "dist/"
   },
   "env": {},


### PR DESCRIPTION
closes #452 to update the deprecated `--prod` option