### PR TITLE
fix(svelte-kit): SvelteKit requires Node 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The following frameworks are detected:
 
 - Static site generators: Gatsby, Hugo, Jekyll, Next.js, Nuxt, Hexo, Gridsome, Docusaurus, Eleventy, Middleman,
   Phenomic, React-static, Stencil, Vuepress, Assemble, DocPad, Harp, Metalsmith, Roots, Wintersmith
-- Front-end frameworks: create-react-app, Vue, Sapper, Angular, Ember, Svelte, Expo, Quasar
+- Front-end frameworks: create-react-app, Vue, SvelteKit, Sapper, Angular, Ember, Svelte, Expo, Quasar
 - Build tools: Parcel, Brunch, Grunt, Gulp
 
 If you're looking for a way to run `framework-info` via CLI check the

--- a/src/frameworks/svelte-kit.json
+++ b/src/frameworks/svelte-kit.json
@@ -17,6 +17,9 @@
     "directory": "build"
   },
   "staticAssetsDirectory": "static",
-  "env": {},
+  "env": {
+    "AWS_LAMBDA_JS_RUNTIME": "nodejs14.x",
+    "NODE_VERSION": "14"
+  },
   "plugins": []
 }


### PR DESCRIPTION
SvelteKit dropped support for Node 12 in https://github.com/sveltejs/kit/pull/2604

I'm not that familiar with this `framework-info` project though. A couple questions:

- Will this affect production deploys as well as development?
- Will these values I specified simple be the defaults and can users override them?