### PR TITLE
chore!: drop support for Node 10

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: ['10.x', '*']
+        node-version: ['12.20.0', '*']
         exclude:
           - os: macOS-latest
-            node-version: '10.x'
+            node-version: '12.20.0'
           - os: windows-latest
-            node-version: '10.x'
+            node-version: '12.20.0'
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/package.json
+++ b/package.json
@@ -122,6 +122,6 @@
     "last 2 ChromeAndroid versions"
   ],
   "engines": {
-    "node": ">=10.18.0"
+    "node": "^12.20.0 || ^14.14.0 || >=16.0.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/netlify/framework-info/issues/450

This drops Node 10 support.

This can be reviewed, but can only be released once https://github.com/netlify/build-info/pull/204 is released.

I will also fix the branch protection rule right before merging this.