### PR TITLE
fix: remove `--ignore-scripts` from `npm publish` in prereleases

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -40,6 +40,6 @@ jobs:
       - name: Push changes
         run: git push --follow-tags
       - name: Run npm publish
-        run: npm publish --tag=${{ steps.extract.outputs.tag }} --ignore-scripts
+        run: npm publish --tag=${{ steps.extract.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
This repository requires the `prepublishOnly` script to build assets before `npm publish`.