### PR TITLE
feat!: add Remix, make dev port optional

### DIFF
--- a/src/frameworks/main.js
+++ b/src/frameworks/main.js
@@ -21,6 +21,7 @@ module.exports.FRAMEWORK_NAMES = [
   'phenomic',
   'react-static',
   'redwoodjs',
+  'remix',
   'stencil',
   'vuepress',
   'assemble',

--- a/src/frameworks/remix.json
+++ b/src/frameworks/remix.json
@@ -1,0 +1,22 @@
+{
+  "id": "remix",
+  "name": "Remix",
+  "category": "static_site_generator",
+  "detect": {
+    "npmDependencies": ["remix", "@remix-run/netlify"],
+    "excludedNpmDependencies": [],
+    "configFiles": ["remix.config.mjs"]
+  },
+  "dev": {
+    "command": "remix watch # needs to also start the static server",
+    "port": 8888,
+    "pollingStrategies": [{ "name": "TCP" }, { "name": "HTTP" }]
+  },
+  "build": {
+    "command": "remix build",
+    "directory": "public"
+  },
+  "staticAssetsDirectory": "public",
+  "env": {},
+  "plugins": []
+}

--- a/src/frameworks/remix.json
+++ b/src/frameworks/remix.json
@@ -8,9 +8,7 @@
     "configFiles": ["remix.config.mjs"]
   },
   "dev": {
-    "command": "remix watch # needs to also start the static server",
-    "port": 8888,
-    "pollingStrategies": [{ "name": "TCP" }, { "name": "HTTP" }]
+    "command": "remix watch"
   },
   "build": {
     "command": "remix build",

--- a/src/frameworks/remix.json
+++ b/src/frameworks/remix.json
@@ -14,7 +14,6 @@
     "command": "remix build",
     "directory": "public"
   },
-  "staticAssetsDirectory": "public",
   "env": {},
   "plugins": []
 }

--- a/test/frameworks.js
+++ b/test/frameworks.js
@@ -86,7 +86,7 @@ const FRAMEWORK_JSON_SCHEMA = {
       oneOf: [
         {
           type: 'object',
-          required: ['command', 'port', 'pollingStrategies'],
+          required: ['command'],
           additionalProperties: false,
           properties: {
             command: COMMAND_SCHEMA,


### PR DESCRIPTION
This starts the process of adding Remix to framework detection. There are a few open questions that I think I need @netlify/integrations to help with:

1. Right now we have to run both `remix watch` and `netlify dev` together and I'm not sure how to approach that or if it's possible to simplify
2. Remix uses port 8888, which I think is going to cause problems and I'm not sure if there's config available to fix it

I'm happy to close this PR if you've already got one rolling. If not, I figured I'd try to get the ball rolling as much as possible so we can get seamless Remix support in place.

Thanks!