### PR TITLE
fix(remix): use correct configuration file

### DIFF
--- a/src/frameworks/remix.json
+++ b/src/frameworks/remix.json
@@ -5,7 +5,7 @@
   "detect": {
     "npmDependencies": ["remix", "@remix-run/netlify"],
     "excludedNpmDependencies": [],
-    "configFiles": ["remix.config.mjs"]
+    "configFiles": ["remix.config.js"]
   },
   "dev": {
     "command": "remix watch"


### PR DESCRIPTION
I believe https://github.com/netlify/framework-info/pull/658 had a typo.

In my Remix project the config is a `.js` file and trying to switch to `.mjs` didn't work (that is changing the extension and using ES modules).