### PR TITLE
chore: disable tests on Firefox

### DIFF
--- a/cypress/run.js
+++ b/cypress/run.js
@@ -10,17 +10,17 @@ import puppeteer from 'puppeteer'
 const DIST_DIR = fileURLToPath(new URL('../dist', import.meta.url))
 
 const versions = [
+  // Chromium 90
   {
-    // Chromium 90
     product: 'chrome',
     version: '856583',
   },
-  {
-    // Old Firefox
-    product: 'firefox',
-    version: '63.0a1',
-    host: 'https://archive.mozilla.org/pub/firefox/nightly/2018/06/2018-06-30-22-02-40-mozilla-central',
-  },
+  // Old Firefox
+  // {
+  //   product: 'firefox',
+  //   version: '63.0a1',
+  //   host: 'https://archive.mozilla.org/pub/firefox/nightly/2018/06/2018-06-30-22-02-40-mozilla-central',
+  // },
 ]
 
 const getBrowserPath = async ({ product, version, host }) => {


### PR DESCRIPTION
Part of https://github.com/netlify/framework-info/issues/714

This disables the Cypress tests on Firefox until we figure out why they are failing.

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/framework-info/issues/new/choose) before writing your code 🧑‍💻. This
      ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a
      typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [x] Update or add tests (if any source code was changed or added) 🧪
- [x] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅