### PR TITLE
fix: fixed typo in qwik excluded dependency

### DIFF
--- a/src/frameworks/vite.json
+++ b/src/frameworks/vite.json
@@ -4,7 +4,7 @@
   "category": "build_tool",
   "detect": {
     "npmDependencies": ["vite"],
-    "excludedNpmDependencies": ["@shopify/hydrogen", "@builderio/qwik", "solid-start"],
+    "excludedNpmDependencies": ["@shopify/hydrogen", "@builder.io/qwik", "solid-start"],
     "configFiles": []
   },
   "dev": {


### PR DESCRIPTION
🎉 Thanks for submitting a pull request! 🎉

#### Summary

There was a typo in the excluded npm dependencies for the vite framework information, causing multiple frameworks to be returned fort Qwik. The typo has been fixed.

Now instead of 

```
❯ ntl dev
Debugger attached.
◈ Netlify Dev ◈
◈ Ignored general context env var: LANG (defined in process)
? Multiple possible start commands found (Use arrow keys or type to search)
❯ [Qwik] 'npm run build.client' 
  [Qwik] 'npm run build.ssr' 
  [Qwik] 'npm run dev.client' 
  [Qwik] 'npm run dev.debug' 
  [Qwik] 'npm run dev.ssr' 
  [Vite] 'npm run build.client' 
  [Vite] 'npm run build.ssr' 
(Move up and down to reveal more choices)
```

when you run `ntl dev`, you'll get the following because only one framework is found.

```
◈ Starting Netlify Dev with Qwik

> build.client
> vite build
```

I think there's another issue when it runs `ntl dev` because it runs the first dev command it finds, e.g. `build.client`, but this is a completely separate issue that needs to be investigate.

Fixes #804

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve and how?
-->

---

For us to review and ship your PR efficiently, please perform the following steps:

- [x] Open a [bug/issue](https://github.com/netlify/framework-info/issues/new/choose) before writing your code 🧑‍💻. This
      ensures we can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a
      typo or something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [x] Read the [contribution guidelines](../CONTRIBUTING.md) 📖. This ensures your code follows our style guide and
      passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [x] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
